### PR TITLE
Fix invalid clang-tidy configuration values

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,11 +25,11 @@ FormatStyle: 'file'
 CheckOptions:
   - { key: google-runtime-int.TypeSufix,                     value: '_t' }
   - { key: fuchsia-restrict-system-includes.Includes,        value: '*,-stdint.h,-stdbool.h,-assert.h' }
-  - { key: readability-identifier-naming.NamespaceCase,       value: snake_case }
-  - { key: readability-identifier-naming.ClassCase,           value: snake_case  }
+  - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,           value: lower_case  }
   - { key: readability-identifier-naming.PrivateMemberPrefix, value: _         }
-  - { key: readability-identifier-naming.StructCase,          value: snake_case  }
-  - { key: readability-identifier-naming.FunctionCase,        value: snake_case }
-  - { key: readability-identifier-naming.VariableCase,        value: snake_case }
-  - { key: readability-identifier-naming.GlobalConstantCase,  value: snake_case }
+  - { key: readability-identifier-naming.StructCase,          value: lower_case  }
+  - { key: readability-identifier-naming.FunctionCase,        value: lower_case }
+  - { key: readability-identifier-naming.VariableCase,        value: lower_case }
+  - { key: readability-identifier-naming.GlobalConstantCase,  value: lower_case }
   - { key: readability-braces-around-statements.ShortStatementLines, value: 2 }


### PR DESCRIPTION
Running `clang-tidy` over this repo - or a project containing this repo as a submodule - results in a bunch of
```
warning: invalid configuration value 'snake_case' for option 'readability-identifier-naming.ClassCase' [clang-tidy-config]
warning: invalid configuration value 'snake_case' for option 'readability-identifier-naming.FunctionCase' [clang-tidy-config]
warning: invalid configuration value 'snake_case' for option 'readability-identifier-naming.GlobalConstantCase' [clang-tidy-config]
warning: invalid configuration value 'snake_case' for option 'readability-identifier-naming.NamespaceCase' [clang-tidy-config]
warning: invalid configuration value 'snake_case' for option 'readability-identifier-naming.StructCase' [clang-tidy-config]
warning: invalid configuration value 'snake_case' for option 'readability-identifier-naming.VariableCase' [clang-tidy-config]
```
Unfortunately, because of the way `clang-tidy` determines which config file to use (at least when using `CXX_CLANG_TIDY` in cmake), this happens for any TU that includes a xenium header, even if xenium's include directory is designated as `SYSTEM` and its headers are filtered out by `HeaderFilterRegex`.

The [correct value](https://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-naming.html) for this option is not `snake_case` but `lower_case`.