### PR TITLE
Fix memory order issues in vyukov_hash_map

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ jobs:
           working_directory: build
       - store_test_results:
             path: build/gtest.xml
+      - store_artifacts:
+            path: build/gtest
       - when:
           condition:
             equal: [ << parameters.build-config >>, "Releass"]
@@ -91,6 +93,8 @@ jobs:
           working_directory: build
       - store_test_results:
             path: build/gtest.xml
+      - store_artifacts:
+            path: build/gtest
       - when:
           condition:
             equal: [ << parameters.build-config >>, "Releass"]
@@ -138,6 +142,8 @@ jobs:
           working_directory: build/<< parameters.build-config >>
       - store_test_results:
             path: build/gtest.xml
+      - store_artifacts:
+            path: build/gtest.exe
 
 
 workflows:
@@ -154,11 +160,11 @@ workflows:
 
   Windows-x64:
     jobs:
-      - build-windows:  
+      - build-windows:
           matrix:
             parameters:
               build-config: ["Debug", "Release"]
-              
+
   Linux-ARM:
     jobs:
       - build-linux:

--- a/test/vyukov_hash_map_test.cpp
+++ b/test/vyukov_hash_map_test.cpp
@@ -433,12 +433,12 @@ TYPED_TEST(VyukovHashMap, parallel_usage) {
     threads.push_back(std::thread([i, &map] {
       for (int k = i * keys_per_thread; k < (i + 1) * keys_per_thread; ++k) {
         for (int j = 0; j < MaxIterations / keys_per_thread; ++j) {
-          [[maybe_unused]] typename Reclaimer::region_guard gaurd{};
+          [[maybe_unused]] typename Reclaimer::region_guard guard{};
           EXPECT_TRUE(map.emplace(k, k));
           for (int x = 0; x < 10; ++x) {
             typename hash_map::accessor acc;
-            EXPECT_TRUE(map.try_get_value(k, acc));
-            EXPECT_EQ(k, *acc);
+            EXPECT_TRUE(map.try_get_value(k, acc)) << "k=" << k << ", j=" << j << ", x=" << x;
+            EXPECT_EQ(k, *acc) << "j=" << j << ", x=" << x;
           }
           if ((j + i) % 8 == 0) {
             for (auto it = map.begin(); it != map.end();) {

--- a/test/vyukov_hash_map_test.cpp
+++ b/test/vyukov_hash_map_test.cpp
@@ -52,6 +52,8 @@ struct managed_ptr_value {
   bool operator==(T* const other) const noexcept {
     return this->v == other->v;
   }
+
+  inline friend std::ostream& operator<<(std::ostream& os, const managed_ptr_value& p) { return os << p.v; }
 };
 
 template <class Key, class Value, class Reclaimer>
@@ -99,6 +101,8 @@ struct VyukovHashMap : ::testing::Test {
   struct node : Reclaimer::template enable_concurrent_ptr<node> {
     explicit node(int v) : v(v) {}
     int v;
+
+    inline friend std::ostream& operator<<(std::ostream& os, const node& n) { return os << n.v; }
   };
 
   using MapValueType =

--- a/test/vyukov_hash_map_test.cpp
+++ b/test/vyukov_hash_map_test.cpp
@@ -384,8 +384,9 @@ TYPED_TEST(VyukovHashMap, parallel_usage) {
           EXPECT_TRUE(this->map.emplace(key, this->make_value(k)));
           for (int x = 0; x < 10; ++x) {
             typename TestFixture::hash_map::accessor acc;
-            EXPECT_TRUE(this->map.try_get_value(key, acc)) << "k=" << k << ", j=" << j << ", x=" << x;
-            EXPECT_EQ(value, *acc) << "j=" << j << ", x=" << x;
+            EXPECT_TRUE(this->map.try_get_value(key, acc))
+              << "k=" << k << ", j=" << j << ", x=" << x << ", thread=" << i;
+            EXPECT_EQ(value, *acc) << "k=" << k << "j=" << j << ", x=" << x << ", thread=" << i;
           }
           if ((j + i) % 8 == 0) {
             for (auto it = this->map.begin(); it != this->map.end();) {
@@ -424,7 +425,7 @@ TYPED_TEST(VyukovHashMap, parallel_usage_with_same_values) {
 
   std::vector<std::thread> threads;
   for (int i = 0; i < 8; ++i) {
-    threads.push_back(std::thread([this] {
+    threads.push_back(std::thread([this, i] {
       for (int j = 0; j < MaxIterations / 10; ++j) {
         for (int k = 0; k < 10; ++k) {
           auto key = this->make_key(k);
@@ -432,11 +433,11 @@ TYPED_TEST(VyukovHashMap, parallel_usage_with_same_values) {
           this->map.emplace(key, this->make_value(k));
           typename TestFixture::hash_map::accessor acc;
           if (this->map.try_get_value(key, acc)) {
-            EXPECT_EQ(this->make_comparison_value(k), *acc);
+            EXPECT_EQ(this->make_comparison_value(k), *acc) << "j=" << j << ", thread=" << i;
           }
 
           if (j % 8 == 0) {
-            // just iterator through the map, but don't really do anything
+            // just iterate through the map, but don't really do anything
             for (auto v : this->map) {
               (void)v;
             }

--- a/xenium/impl/vyukov_hash_map.hpp
+++ b/xenium/impl/vyukov_hash_map.hpp
@@ -257,8 +257,10 @@ retry:
   }
 
   if (item_count < bucket_item_count) {
+    // (42) - these release-store synchronize-with the acquire-loads (41) (key) and (24) (value)
+    // we need to use release even though we have lock because concurrent find can still observe our changes
     traits::template store_item<AcquireAccessor>(
-      bucket.key[item_count], bucket.value[item_count], h, std::move(key), factory(), std::memory_order_relaxed, acc);
+      bucket.key[item_count], bucket.value[item_count], h, std::move(key), factory(), std::memory_order_release, acc);
     callback(std::move(acc), bucket.value[item_count]);
     // release the bucket lock and increment the item count
     // (3) - this release-store synchronizes-with the acquire-CAS (7, 30, 34, 37) and the acquire-load (23)
@@ -283,8 +285,14 @@ retry:
     goto retry;
   }
   try {
+    // we need to use memory_order_release here because the extension item could be reused,
+    // so a concurrent lookup could potentially observe our writes. Without a release-store
+    // we would have no happens-before relation to ensure that the lookup operation also observes
+    // the update to the bucket state to realize that the values it just read from our extension
+    // item cannot be used.
+    // (43) - these release-store synchronize-with the acquire-load (44) (key) and (26) (value)
     traits::template store_item<AcquireAccessor>(
-      extension->key, extension->value, h, std::move(key), factory(), std::memory_order_relaxed, acc);
+      extension->key, extension->value, h, std::move(key), factory(), std::memory_order_release, acc);
   } catch (...) {
     free_extension_item(extension);
     throw;
@@ -525,12 +533,12 @@ retry:
 
   std::uint32_t item_count = state.item_count();
   for (std::uint32_t i = 0; i != item_count; ++i) {
-    // (41) - this acquire-load synchronizes-with the release-store (39, 40)
+    // (41) - this acquire-load synchronizes-with the release-store (39, 40, 42)
     if (traits::compare_trivial_key(bucket.key[i].load(std::memory_order_acquire), key, h)) {
       // use acquire semantic here - should synchronize-with the release store to value
       // in remove() to ensure that if we see the changed value here we also see the
       // changed state in the subsequent reload of state
-      // (24) - this acquire-load synchronizes-with the release-store (8, 12, 16, 20)
+      // (24) - this acquire-load synchronizes-with the release-store (8, 12, 16, 20, 42)
       accessor acc = traits::acquire(bucket.value[i], std::memory_order_acquire);
 
       // ensure that we can use the value we just read
@@ -567,11 +575,9 @@ retry:
   // (25) - this acquire-load synchronizes-with the release-store (4, 10, 18)
   extension_item* extension = bucket.head.load(std::memory_order_acquire);
   while (extension) {
-    if (traits::compare_trivial_key(extension->key.load(std::memory_order_relaxed), key, h)) {
-      // TODO - this acquire does not synchronize with anything ATM.
-      // However, this is probably required when introducing an update-method that
-      // allows to store a new value.
-      // (26) - this acquire-load synchronizes-with <nothing>
+    // (44) - this acquire-load synchronize-with the release-store (43)
+    if (traits::compare_trivial_key(extension->key.load(std::memory_order_acquire), key, h)) {
+      // (26) - this acquire-load synchronizes-with the release-store (43)
       accessor acc = traits::acquire(extension->value, std::memory_order_acquire);
 
       auto state2 = bucket.state.load(std::memory_order_relaxed);

--- a/xenium/impl/vyukov_hash_map.hpp
+++ b/xenium/impl/vyukov_hash_map.hpp
@@ -463,9 +463,10 @@ void vyukov_hash_map<Key, Value, Policies...>::erase(iterator& pos) {
 
     auto k = extension->key.load(std::memory_order_relaxed);
     auto v = extension->value.load(std::memory_order_relaxed);
-    pos.current_bucket->key[pos.index].store(k, std::memory_order_relaxed);
-    // (16) - this release-store synchronizes-with the acquire-load (24)
+    // (16)  - this release-store synchronizes-with the acquire-load (24)
     pos.current_bucket->value[pos.index].store(v, std::memory_order_release);
+    // (45) - this release-store synchronizes-with the acquire-load (41)
+    pos.current_bucket->key[pos.index].store(k, std::memory_order_release);
 
     // reset the delete marker
     locked_state = locked_state.new_version();
@@ -493,9 +494,10 @@ void vyukov_hash_map<Key, Value, Policies...>::erase(iterator& pos) {
 
       auto k = pos.current_bucket->key[max_index].load(std::memory_order_relaxed);
       auto v = pos.current_bucket->value[max_index].load(std::memory_order_relaxed);
-      pos.current_bucket->key[pos.index].store(k, std::memory_order_relaxed);
-      // (20) - this release-store synchronizes-with the acquire-load  (24)
+      // (20)  - this release-store synchronizes-with the acquire-load (24)
       pos.current_bucket->value[pos.index].store(v, std::memory_order_release);
+      // (46) - this release-store synchronizes-with the acquire-load (41)
+      pos.current_bucket->key[pos.index].store(k, std::memory_order_release);
     }
 
     auto new_state = pos.current_bucket_state.new_version().dec_item_count();

--- a/xenium/impl/vyukov_hash_map.hpp
+++ b/xenium/impl/vyukov_hash_map.hpp
@@ -545,8 +545,15 @@ retry:
       const auto state2 = bucket.state.load(std::memory_order_relaxed);
       if (state.version() != state2.version()) {
         // a deletion has occurred in the meantime -> we have to retry
-        state = state2;
         goto retry;
+      }
+
+      if (traits::load_value(acc)) {
+        const auto state2 = bucket.state.load(std::memory_order_relaxed);
+        if (state.version() != state2.version()) {
+          // a deletion has occurred in the meantime -> we have to retry
+          goto retry;
+        }
       }
 
       const auto delete_marker = i + 1;
@@ -582,9 +589,16 @@ retry:
 
       auto state2 = bucket.state.load(std::memory_order_relaxed);
       if (state.version() != state2.version()) {
-        // a deletion has occured in the meantime -> we have to retry
-        state = state2;
+        // a deletion has occurred in the meantime -> we have to retry
         goto retry;
+      }
+
+      if (traits::load_value(acc)) {
+        auto state2 = bucket.state.load(std::memory_order_relaxed);
+        if (state.version() != state2.version()) {
+          // a deletion has occurred in the meantime -> we have to retry
+          goto retry;
+        }
       }
 
       if (!traits::compare_nontrivial_key(acc, key)) {

--- a/xenium/impl/vyukov_hash_map_traits.hpp
+++ b/xenium/impl/vyukov_hash_map_traits.hpp
@@ -21,10 +21,7 @@ namespace bits {
 
   template <class Key>
   struct vyukov_hash_map_trivial_key : vyukov_hash_map_common<Key> {
-    template <class Cell>
-    static bool compare_trivial_key(Cell& key_cell, const Key& key, hash_t /*hash*/) {
-      return key_cell.load(std::memory_order_relaxed) == key;
-    }
+    static bool compare_trivial_key(Key key1, Key key2, hash_t /*hash*/) { return key1 == key2; }
 
     template <class Accessor>
     static bool compare_nontrivial_key(const Accessor&, const Key&) {
@@ -39,10 +36,7 @@ namespace bits {
 
   template <class Key>
   struct vyukov_hash_map_nontrivial_key : vyukov_hash_map_common<Key> {
-    template <class Cell>
-    static bool compare_trivial_key(Cell& key_cell, const Key& /*key*/, hash_t hash) {
-      return key_cell.load(std::memory_order_relaxed) == hash;
-    }
+    static bool compare_trivial_key(hash_t hash1, const Key& /*key*/, hash_t hash2) { return hash1 == hash2; }
 
     template <class Accessor>
     static bool compare_nontrivial_key(const Accessor& acc, const Key& key) {

--- a/xenium/impl/vyukov_hash_map_traits.hpp
+++ b/xenium/impl/vyukov_hash_map_traits.hpp
@@ -85,8 +85,8 @@ struct vyukov_hash_map_traits<Key, managed_ptr<Value, VReclaimer>, ValueReclaime
                          Value* v,
                          std::memory_order order,
                          accessor& acc) {
-    key_cell.store(k, std::memory_order_relaxed);
     value_cell.store(v, order);
+    key_cell.store(k, order);
     if (AcquireAccessor) {
       acc.guard = typename storage_value_type::guard_ptr(v);
     }
@@ -170,8 +170,8 @@ struct vyukov_hash_map_traits<Key, managed_ptr<Value, VReclaimer>, ValueReclaime
       acc.node_guard = typename storage_value_type::guard_ptr(n); // TODO - is this necessary?
       acc.value_guard = typename VReclaimer::template concurrent_ptr<Value>::guard_ptr(v);
     }
-    key_cell.store(hash, std::memory_order_relaxed);
     value_cell.store(n, order);
+    key_cell.store(hash, order);
   }
 
   template <bool AcquireAccessor>
@@ -246,8 +246,8 @@ struct vyukov_hash_map_traits<Key, Value, ValueReclaimer, Reclaimer, true, true>
                          Value v,
                          std::memory_order order,
                          accessor& acc) {
-    key_cell.store(k, std::memory_order_relaxed);
     value_cell.store(v, order);
+    key_cell.store(k, order);
     if (AcquireAccessor) {
       acc.v = v;
     }
@@ -334,8 +334,8 @@ struct vyukov_hash_map_traits<Key, Value, ValueReclaimer, Reclaimer, true, false
     if (AcquireAccessor) {
       acc.guard = typename storage_value_type::guard_ptr(n);
     }
-    key_cell.store(k, std::memory_order_relaxed);
     value_cell.store(n, order);
+    key_cell.store(k, order);
   }
 
   static iterator_reference deref_iterator(storage_key_type& k, storage_value_type& v) {
@@ -399,8 +399,8 @@ struct vyukov_hash_map_traits<Key, Value, ValueReclaimer, Reclaimer, false, Triv
     if (AcquireAccessor) {
       acc.guard = typename storage_value_type::guard_ptr(n);
     }
-    key_cell.store(hash, std::memory_order_relaxed);
     value_cell.store(n, order);
+    key_cell.store(hash, order);
   }
 
   template <bool AcquireAccessor>

--- a/xenium/impl/vyukov_hash_map_traits.hpp
+++ b/xenium/impl/vyukov_hash_map_traits.hpp
@@ -76,6 +76,7 @@ struct vyukov_hash_map_traits<Key, managed_ptr<Value, VReclaimer>, ValueReclaime
   };
 
   static accessor acquire(storage_value_type& v, std::memory_order order) { return accessor(v, order); }
+  static constexpr bool load_value(accessor&) { return false; }
 
   template <bool AcquireAccessor>
   static void store_item(storage_key_type& key_cell,
@@ -148,9 +149,13 @@ struct vyukov_hash_map_traits<Key, managed_ptr<Value, VReclaimer>, ValueReclaime
     }
 
   private:
-    accessor(storage_value_type& v, std::memory_order order) :
-        node_guard(acquire_guard(v, order)),
-        value_guard(acquire_guard(node_guard->value, order)) {}
+    accessor(storage_value_type& v, std::memory_order order) : node_guard(acquire_guard(v, order)) {}
+    // TODO - can this be relaxed? Probably yes since the node is immutable after creation.
+    // But that is actually a problem because ATM a node returned in an accessor from extract cannot be reclaimed.
+    void load_value() { value_guard = acquire_guard(node_guard->value, std::memory_order_relaxed); }
+
+    typename storage_value_type::guard_ptr guard;
+    friend struct vyukov_hash_map_traits;
     [[nodiscard]] const Key& key() const { return node_guard->key; }
     typename storage_value_type::guard_ptr node_guard;
     typename VReclaimer::template concurrent_ptr<Value>::guard_ptr value_guard;
@@ -159,6 +164,10 @@ struct vyukov_hash_map_traits<Key, managed_ptr<Value, VReclaimer>, ValueReclaime
   };
 
   static accessor acquire(storage_value_type& v, std::memory_order order) { return accessor(v, order); }
+  static bool load_value(accessor& acc) {
+    acc.load_value();
+    return true;
+  }
 
   template <bool AcquireAccessor>
   static void store_item(storage_key_type& key_cell,
@@ -246,6 +255,7 @@ struct vyukov_hash_map_traits<Key, Value, ValueReclaimer, Reclaimer, true, true>
 
   static void reset(accessor&&) {}
   static accessor acquire(storage_value_type& v, std::memory_order order) { return accessor(v, order); }
+  static constexpr bool load_value(accessor&) { return false; }
 
   template <bool AcquireAccessor>
   static void store_item(storage_key_type& key_cell,
@@ -315,6 +325,7 @@ struct vyukov_hash_map_traits<Key, Value, ValueReclaimer, Reclaimer, true, false
   };
 
   static accessor acquire(storage_value_type& v, std::memory_order order) { return accessor(v, order); }
+  static constexpr bool load_value(accessor&) { return false; }
 
   template <bool AcquireAccessor>
   static bool compare_key(storage_key_type& key_cell,
@@ -401,6 +412,7 @@ struct vyukov_hash_map_traits<Key, Value, ValueReclaimer, Reclaimer, false, Triv
   };
 
   static accessor acquire(storage_value_type& v, std::memory_order order) { return accessor(v, order); }
+  static constexpr bool load_value(accessor&) { return false; }
 
   template <bool AcquireAccessor>
   static void store_item(storage_key_type& key_cell,

--- a/xenium/kirsch_kfifo_queue.hpp
+++ b/xenium/kirsch_kfifo_queue.hpp
@@ -316,13 +316,15 @@ bool kirsch_kfifo_queue<T, Policies...>::committed(marked_ptr segment, marked_va
 
   const marked_value empty_value(nullptr, value.mark() + 1);
 
-  if (segment->deleted.load(std::memory_order_relaxed)) {
+  // (TODO)
+  if (segment->deleted.load(std::memory_order_seq_cst)) {
     // Insert tail segment has been removed, but we are fine if element still has been removed.
     return !segment->items()[index].value.compare_exchange_strong(value, empty_value, std::memory_order_relaxed);
   }
 
+  // (TODO)
   // (6) - this acquire-load synchronizes-with the release-CAS (10)
-  marked_ptr head_current = head_.load(std::memory_order_acquire);
+  marked_ptr head_current = head_.load(std::memory_order_seq_cst);
   if (segment.get() == head_current.get()) {
     // Insert tail segment is now head.
     marked_ptr new_head(head_current.get(), head_current.mark() + 1);
@@ -337,7 +339,8 @@ bool kirsch_kfifo_queue<T, Policies...>::committed(marked_ptr segment, marked_va
     return !segment->items()[index].value.compare_exchange_strong(value, empty_value, std::memory_order_relaxed);
   }
 
-  if (!segment->deleted.load(std::memory_order_relaxed)) {
+  // (TODO)
+  if (!segment->deleted.load(std::memory_order_seq_cst)) {
     // Insert tail segment still not deleted.
     return true;
   }
@@ -368,12 +371,14 @@ void kirsch_kfifo_queue<T, Policies...>::advance_head(guard_ptr& head_current, m
     }
   }
 
-  head_current->deleted.store(true, std::memory_order_relaxed);
+  // (TODO)
+  head_current->deleted.store(true, std::memory_order_seq_cst);
 
   marked_ptr expected = head_current;
   marked_ptr new_head(head_next_segment.get(), head_current.mark() + 1);
   // (10) - this release-CAS synchronizes-with the acquire-load (3, 6)
-  if (head_.compare_exchange_strong(expected, new_head, std::memory_order_release, std::memory_order_relaxed)) {
+  // (TODO)
+  if (head_.compare_exchange_strong(expected, new_head, std::memory_order_seq_cst, std::memory_order_relaxed)) {
     head_current.reclaim();
   }
 }

--- a/xenium/vyukov_hash_map.hpp
+++ b/xenium/vyukov_hash_map.hpp
@@ -412,7 +412,6 @@ private:
 
 #define XENIUM_VYUKOV_HASH_MAP_IMPL
 #include <xenium/impl/vyukov_hash_map.hpp>
-#include <xenium/impl/vyukov_hash_map_traits.hpp>
 #undef XENIUM_VYUKOV_HASH_MAP_IMPL
 
 #endif


### PR DESCRIPTION
This PR fixes a few memory order issues in the vyukov_hash_map that surfaced in the ARM tests. The kirsch queue tests also occasionally fail, but that one still requires more investigation,